### PR TITLE
Prevent NaN values for ETAs when receiving a polling update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.1.9](https://github.com/mjk/uber-rush/tree/0.1.9) (2016-08-29)
+**Merged pull requests:**
+
+-  Prevent NaN values for ETAs when receiving a polling update [\#8](https://github.com/mjk/uber-rush/pull/8) ([beum](https://github.com/beum))
+
+
 ## [0.1.8](https://github.com/mjk/uber-rush/tree/0.1.8) (2016-08-17)
 **Closed issues:**
 

--- a/lib/Dropoff.js
+++ b/lib/Dropoff.js
@@ -10,24 +10,25 @@ var Location = require('./Location');
 
   @param contact Contact Contact person for the dropoff
   @param location Location Location address for the dropoff
-  @param signature_required boolean 
+  @param signature_required boolean
   @param special_instructions string
 */
 
 class Dropoff {
   constructor(options) {
     _.each(options, (value, key) => {
-        if (key == 'contact' && !(value instanceof Contact)) {
-            value = new Contact(value);
+      if (key == 'contact' && !(value instanceof Contact)) {
+        value = new Contact(value);
+      } else if (key == 'location' && !(value instanceof Location)) {
+        value = new Location(value);
+      } else if (key == 'eta') {
+        value = parseInt(key, 10);
+        if (isNaN(value)) {
+          value = null;
         }
-        else if (key == 'location' && !(value instanceof Location)) {
-            value = new Location(value);
-        }
-        else if (key == 'eta') {
-            value = parseInt(key, 10);
-        }
+      }
 
-        this[key] = value;
+      this[key] = value;
     });
   }
 

--- a/lib/Pickup.js
+++ b/lib/Pickup.js
@@ -10,7 +10,7 @@ var Location = require('./Location');
 
   @param contact Contact Contact person for the dropoff
   @param location Location Location address for the dropoff
-  @param signature_required boolean 
+  @param signature_required boolean
   @param special_instructions string
 */
 
@@ -19,12 +19,13 @@ class Pickup {
     _.each(options, (value, key) => {
       if (key == 'contact' && !(value instanceof Contact)) {
         value = new Contact(value);
-      }
-      else if (key == 'location' && !(value instanceof Location)) {
+      } else if (key == 'location' && !(value instanceof Location)) {
         value = new Location(value);
-      }
-      else if (key == 'eta') {
+      } else if (key == 'eta') {
         value = parseInt(key, 10);
+        if (isNaN(value)) {
+          value = null;
+        }
       }
 
       this[key] = value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uber-rush",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "UberRUSH v3.0 SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently when either ETA value comes back as null or undefined it results in an NaN value on the object.  This patch sets it to null instead for more predictable handling.