### PR TITLE
Switched to google-libphonenumber.

### DIFF
--- a/lib/Contact.js
+++ b/lib/Contact.js
@@ -36,14 +36,14 @@ class Contact {
                 console.error('Unable to parse phone number [' + value.number + ']', e);
               }
             } else {
-              // rethrow if we can't massage it
-              throw e;
+              // TODO also be strict if we're in the sandbox env
+              if (options.strict) throw e;
             }
           }
         }
 
         value = {
-          number: parsedNumber ? phoneUtil.format(parsedNumber, PNF.E164) : null,
+          number: parsedNumber ? phoneUtil.format(parsedNumber, PNF.E164) : value.number,
           sms_enabled: value.sms_enabled || false
         };
       }

--- a/lib/Contact.js
+++ b/lib/Contact.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
-const phone = require('phone');
+const phone = require('google-libphonenumber');
+const PNF = phone.PhoneNumberFormat;
+const phoneUtil = phone.PhoneNumberUtil.getInstance();
 
 /**
   A contact.
@@ -18,9 +20,30 @@ const phone = require('phone');
 class Contact {
   constructor(options) {
     _.each(options, (value, key) => {
-      if (key == 'phone') {
+      if (key == 'phone' && value) {
+        let parsedNumber;
+
+        if (value.number) {
+          try { 
+            parsedNumber = phoneUtil.parse(value.number);
+          } catch (e) {
+            // Try adding +1 if number is 10+ chars but lacks country code,
+            // as UberRush is only available in the US as of now.
+            if (value.number.indexOf('+1') === -1 && value.number.replace(/ /g,'').length >= 10) {
+              try { 
+                parsedNumber = phoneUtil.parse('+1' + value.number);
+              } catch (e) {
+                console.error('Unable to parse phone number [' + value.number + ']', e);
+              }
+            } else {
+              // rethrow if we can't massage it
+              throw e;
+            }
+          }
+        }
+
         value = {
-          number: phone(value.number).length > 0 ? phone(value.number)[0] : null,
+          number: parsedNumber ? phoneUtil.format(parsedNumber, PNF.E164) : null,
           sms_enabled: value.sms_enabled || false
         };
       }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "homepage": "https://github.com/mjk/uber-rush#readme",
   "dependencies": {
     "geodesy": "^1.0.2",
+    "google-libphonenumber": "^2.0.2",
     "lodash": "^3.10.1",
     "nconf": "^0.8.2",
-    "phone": "^1.0.5",
     "q": "^1.4.1",
     "restling": "^0.9.1"
   },

--- a/test/unit/contact.spec.js
+++ b/test/unit/contact.spec.js
@@ -14,25 +14,31 @@ describe('Contacts', function() {
 
   it('Contact should accept a variety of American numbers', function() {
     assert.doesNotThrow(() => {
-      new rush.Contact(deliveryConfig.pickup.contact);
-      new rush.Contact(deliveryConfig.dropoff.contact);
-      new rush.Contact({phone:{number: '844-555-5555'}});
-      new rush.Contact({phone:{number: '855-555-5555'}});
-      new rush.Contact({phone:{number: '900-555-5555'}});
-      new rush.Contact({phone:{number: '800-555-5555'}});
-      new rush.Contact({phone:{number: '716-555-5555'}});
-      new rush.Contact({phone:{number: '+1 212 555 1212'}});
-      new rush.Contact({phone:{number: '+1 844 555 1212'}});
+      new rush.Contact(Object.assign(deliveryConfig.pickup.contact, {strict: 1}));
+      new rush.Contact(Object.assign(deliveryConfig.dropoff.contact, {strict: 1}));
+      new rush.Contact({strict: 1, phone:{number: '844-555-5555'}});
+      new rush.Contact({strict: 1, phone:{number: '855-555-5555'}});
+      new rush.Contact({strict: 1, phone:{number: '900-555-5555'}});
+      new rush.Contact({strict: 1, phone:{number: '800-555-5555'}});
+      new rush.Contact({strict: 1, phone:{number: '716-555-5555'}});
+      new rush.Contact({strict: 1, phone:{number: '+1 212 555 1212'}});
+      new rush.Contact({strict: 1, phone:{number: '+1 844 555 1212'}});
     });
   });
 
   it('Contact should not accept invalid numbers', function() {
     assert.throws(() => {
-      new rush.Contact({phone:{number: '555 1212'}});
+      new rush.Contact({strict: 1, phone:{number: '555 1212'}});
     });
     assert.throws(() => {
-      new rush.Contact({phone:{number: '1 555 12'}});
+      new rush.Contact({strict: 1, phone:{number: '1 555 12'}});
     });
   });
 
+  it('Contact should not throw invalid number errors outside of strict mode', function() {
+    assert.doesNotThrow(() => {
+      new rush.Contact({phone:{number: '555 1212'}});
+      new rush.Contact({phone:{number: '1 555 12'}});
+    });
+  });
 })

--- a/test/unit/contact.spec.js
+++ b/test/unit/contact.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('assert');
+const rush = require('../../index');
+const config = require('../dummy/config');
+const deliveryConfig = require('../dummy/delivery').fullDelivery;
+
+describe('Contacts', function() {
+  const client = rush.createClient(config);
+
+  it('rush.Contact should exist', function() {
+    assert(!!rush.Contact);
+  });
+
+  it('Contact should accept a variety of American numbers', function() {
+    assert.doesNotThrow(() => {
+      new rush.Contact(deliveryConfig.pickup.contact);
+      new rush.Contact(deliveryConfig.dropoff.contact);
+      new rush.Contact({phone:{number: '844-555-5555'}});
+      new rush.Contact({phone:{number: '855-555-5555'}});
+      new rush.Contact({phone:{number: '900-555-5555'}});
+      new rush.Contact({phone:{number: '800-555-5555'}});
+      new rush.Contact({phone:{number: '716-555-5555'}});
+      new rush.Contact({phone:{number: '+1 212 555 1212'}});
+      new rush.Contact({phone:{number: '+1 844 555 1212'}});
+    });
+  });
+
+  it('Contact should not accept invalid numbers', function() {
+    assert.throws(() => {
+      new rush.Contact({phone:{number: '555 1212'}});
+    });
+    assert.throws(() => {
+      new rush.Contact({phone:{number: '1 555 12'}});
+    });
+  });
+
+})


### PR DESCRIPTION
Former module phone appears to be out of date vis-a-vis area code
support.

 - Will assume numbers are US if not indicated and logical to do so
 - Added a few unit tests for valid/invalid numbers

@beum @pstoica Would you rather fail silently if a number appears invalid, or have an error thrown?