### PR TITLE
Single-item inclusion

### DIFF
--- a/lib/Delivery.js
+++ b/lib/Delivery.js
@@ -42,6 +42,11 @@ class Delivery extends EventEmitter {
     if (options.dropoff) this.setDropoff(options.dropoff);
     if (options.delivery_id) this.delivery_id = options.delivery_id;
     if (options.order_reference_id) this.order_reference_id = options.order_reference_id;
+
+    // Convenience method for a single-item delivery
+    if (options.item) {
+      this.addItem(options.item);
+    }
   }
 
   addItem(item) {

--- a/lib/Item.js
+++ b/lib/Item.js
@@ -17,12 +17,12 @@ class Item {
   constructor(options) {
     this.title = options.title;
     this.quantity = options.quantity;
-    this.width = options.width;
-    this.height = options.height;
-    this.length = options.length;
-    this.price = options.price;
-    this.currency_code = options.currency_code;
-    this.is_fragile = options.is_fragile;
+    if (options.width) this.width = options.width;
+    if (options.height) this.height = options.height;
+    if (options.length) this.length = options.length;
+    if (options.price) this.price = options.price;
+    if (options.currency_code) this.currency_code = options.currency_code;
+    this.is_fragile = options.is_fragile || false;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uber-rush",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "UberRUSH v3.0 SDK",
   "main": "index.js",
   "scripts": {

--- a/test/unit/delivery.spec.js
+++ b/test/unit/delivery.spec.js
@@ -5,6 +5,8 @@ const rush = require('../../index');
 const config = require('../dummy/config');
 const deliveryConfig = require('../dummy/delivery').fullDelivery;
 
+const client = rush.createClient(config);
+
 describe('testing delivery creation', function() {
   const client = rush.createClient(config);
 
@@ -67,6 +69,19 @@ describe('testing delivery creation', function() {
     });
   });
 
+  it('Delivery should automatically add single items', function() {
+    let delivery = client.createDelivery({
+      item: {
+        title: 'a fun item',
+        quantity: 1
+      }
+    });
+
+    assert(delivery.items instanceof Array);
+    assert(delivery.items.length == 1);
+    assert(delivery.items[0].title == 'a fun item');
+  });
+
   it('Delivery should provide quote method', function() {
     let delivery = new rush.Delivery(deliveryConfig);
 
@@ -75,4 +90,31 @@ describe('testing delivery creation', function() {
       //delivery.quote();
     });
   });
-})
+
+  it('Delivery should provide getRatings method', function() {
+    let delivery = new rush.Delivery(deliveryConfig);
+
+    assert(typeof delivery.getRatings == 'function');
+    assert.throws(() => {
+      delivery.getRatings();
+    });
+    assert.doesNotThrow(() => {
+      try {
+      delivery.getRatings({delivery_id: 'foo'}).then(console.log);
+      } catch (e) {
+        console.error(e);
+      }
+    });
+  });
+
+  it('Delivery should provide rate method', function() {
+    let delivery = new rush.Delivery(deliveryConfig);
+
+    assert(typeof delivery.rate == 'function');
+    assert.throws(() => {
+      delivery.rate();
+      delivery.rate({});
+      delivery.rate({waypoint: 'foobar'});
+    });
+  });
+});


### PR DESCRIPTION
Hate manually adding items? Single-item orders (perhaps the most common use case) can now be included on initialization.

```
UberRUSH.createDelivery({
  item: {
    title: 'one of my favorite things'
    quantity: 1
  }, 
  ...
})
```

TODO in the future: support `items: [{...}...]`